### PR TITLE
Update broccoli-filter to enable symlink consumption.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "MIT"
   ],
   "dependencies": {
-    "broccoli-filter": "~0.1.6",
+    "broccoli-filter": "~0.1.7",
     "ember-template-compiler": "~1.5.0",
     "emblem": "~0.3.18"
   },


### PR DESCRIPTION
Does not introduce symlinks, but it does allow this filter to work if symlinks exist in the input tree.

This is mostly an issue with npm package lookup (causing broccoli-emblem-compiler to receive an older non-symlinking aware version of broccoli-filter's dependencies).
