### PR TITLE
Lock the version of emblem

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "broccoli-filter": "^0.1.10",
     "ember-template-compiler": "git+https://github.com/toranb/ember-template-compiler.git",
-    "emblem": "git+https://github.com/machty/emblem.js.git#0.3.18"
+    "emblem": "0.3.18"
   },
   "devDependencies": {},
   "optionalDependencies": {}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "broccoli-filter": "^0.1.10",
     "ember-template-compiler": "git+https://github.com/toranb/ember-template-compiler.git",
-    "emblem": "git+https://github.com/machty/emblem.js.git"
+    "emblem": "git+https://github.com/machty/emblem.js.git#0.3.18"
   },
   "devDependencies": {},
   "optionalDependencies": {}


### PR DESCRIPTION
Breaking changes pushed to emblem project. To ensure this does not happen again, this project can lock its dependency on emblem to a specific version.

```
Build failed.
File: ember-cli/templates/clients-view.emblem
Cannot read property 'original' of undefined
TypeError: Cannot read property 'original' of undefined
  at new AST.BlockNode (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/handlebars/dist/cjs/handlebars/compiler/ast.js:112:49)
  at peg$c34 (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:201:23)
  at peg$parsemustacheOrBlock (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:1552:20)
  at peg$parseexplicitMustache (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:1801:14)
  at peg$parsemustache (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:982:12)
  at peg$parsecontentStatement (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:829:18)
  at peg$parsestatement (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:807:16)
  at peg$parsecontent (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:780:12)
  at peg$parseinvertibleContent (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:642:12)
  at peg$parsestart (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:633:12)
  at Object.parse (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/parser.js:6450:18)
  at Object.Emblem.parse (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/compiler.js:22:26)
  at Object.Emblem.precompile (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/emblem/lib/compiler.js:44:16)
  at TemplateCompiler.processString (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/index.js:29:27)
  at TemplateCompiler.Filter.processFile (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/broccoli-filter/index.js:136:31)
  at Promise.resolve.then.catch.err.file (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/broccoli-filter/index.js:82:21)
  at lib$rsvp$$internal$$tryCatch (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/broccoli-filter/node_modules/rsvp/dist/rsvp.js:489:16)
  at lib$rsvp$$internal$$invokeCallback (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/broccoli-filter/node_modules/rsvp/dist/rsvp.js:501:17)
  at /home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/broccoli-filter/node_modules/rsvp/dist/rsvp.js:1095:13
  at Object.lib$rsvp$asap$$flush [as _onImmediate] (/home/julian/Developer/ember/ember-web/dashboard/node_modules/ember-cli-emblem/node_modules/broccoli-emblem-compiler/node_modules/broccoli-filter/node_modules/rsvp/dist/rsvp.js:1290:9)
  at processImmediate [as _immediateCallback] (timers.js:345:15)
```
